### PR TITLE
feat: adição do sonarqube no projeto e instrução de como rodar

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -14,6 +14,7 @@ kubectl config set-context --current --namespace=file-flow
 kubectl apply -f k8s/postgres
 kubectl apply -f k8s/redis
 kubectl apply -f k8s/fluent-bit
+kubectl apply -f k8s/sonar
 helm install graylog ./k8s/graylog/ -n file-flow
 
 kubectl apply -f k8s/fileflow
@@ -26,6 +27,7 @@ kubectl delete -f k8s/fileflow
 kubectl delete -f k8s/fileflow-front
 kubectl delete -f k8s/postgres
 kubectl delete -f k8s/redis
+kubectl delete -f k8s/sonar
 helm uninstall graylog -n file-flow
 ```
 
@@ -65,7 +67,38 @@ Unico porem que não vai categorizar os logs, vai ser apenas um log.
 Precisa ir em System -> Inputs e obter o Id destes inputs(codigo varia sempre), atraves do show received messages.
 Usar este gl2_source_input:68554048908334446a4cda76 para configurar os filtros no Streams.
 
+### Configurar Sonarqube
 
+Pegar a URL de acesso do Sonarqube
 
+```bash
+minikube -n file-flow service sonarqube-svc --url
+```
 
+Acessar o Sonarqube na url retornada pelo comando acima
+Realizar login com as credenciais
+```bash
+login: admin
+password: admin
+```
+Após realizar login, será necessário alterar a senha do usuário admin.
 
+Após a alteração de senha, será necessário criar um token de autenticação para o Sonarqube.
+Acessar o perfil, no canto superior direito, clicar em "My Account" -> "Security" e criar um token de autenticação.
+Após criar o token, copiar o token gerado, pois não será possível visualizá-lo novamente.
+
+Rodar o verify do maven, na raiz do projeto
+```bash
+mvn clean verify sonar:sonar \
+  -Dsonar.projectKey=file-flow \
+  -Dsonar.projectName="Fileflow" \
+  -Dsonar.host.url=<URL_DO_SONARQUBE> \
+  -Dsonar.login=<TOKEN_GERADO>
+```
+O projeto será buildado, testes serão executados, é necessário que o comando ocorra sem erros e o Sonarqube será atualizado com as informações do projeto.
+Apósa execução do comando, acessar o Sonarqube na url retornada pelo comando acima e verificar se o projeto foi adicionado corretamente.
+Pode demorar alguns minutos para que o Sonarqube processe as informações do projeto e exiba os resultados.
+Será retornada uma URL para visualizar o dashboard criado do projeto no Sonarqube, exemplo:
+```
+[INFO] 08:10:42.430 ANALYSIS SUCCESSFUL, you can find the results at: http://127.0.0.1:40111/dashboard?id=file-flow
+```

--- a/k8s/sonar/sonarqube-deploy.yml
+++ b/k8s/sonar/sonarqube-deploy.yml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: sonarqube
+    namespace: file-flow
+    labels:
+        app: sonarqube
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: sonarqube
+    template:
+        metadata:
+            labels:
+                app: sonarqube
+        spec:
+            containers:
+                - name: sonarqube
+                  image: sonarqube:latest
+                  ports:
+                      - containerPort: 9000
+                  env:
+                      - name: SONAR_ES_BOOTSTRAP_CHECKS_DISABLE
+                        value: "true"
+                  resources:
+                      requests:
+                          memory: "2Gi"
+                          cpu: "1000m"
+                      limits:
+                          memory: "4Gi"
+                          cpu: "2000m"

--- a/k8s/sonar/sonarqube-svc.yml
+++ b/k8s/sonar/sonarqube-svc.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: sonarqube-svc
+    namespace: file-flow
+spec:
+    type: NodePort
+    selector:
+        app: sonarqube
+    ports:
+        - port: 9000
+          targetPort: 9000
+          nodePort: 30091


### PR DESCRIPTION
O Sonarqube foi criado com um uso maior de recursos no K8S pois estava muito lento com poucos recursos, quando foi aumentado a performance ficou muito melhor.

Print do sonarqube no local:

![image](https://github.com/user-attachments/assets/250cc0d5-4910-44b2-9a60-557fe310f970)
